### PR TITLE
Benchmark for sequence compression API

### DIFF
--- a/contrib/seqBench/Makefile
+++ b/contrib/seqBench/Makefile
@@ -1,0 +1,58 @@
+# ################################################################
+# Copyright (c) 2018-present, Yann Collet, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under both the BSD-style license (found in the
+# LICENSE file in the root directory of this source tree) and the GPLv2 (found
+# in the COPYING file in the root directory of this source tree).
+# ################################################################
+
+PROGDIR = ../../programs
+LIBDIR  = ../../lib
+
+LIBZSTD = $(LIBDIR)/libzstd.a
+
+CPPFLAGS+= -I$(LIBDIR) -I$(LIBDIR)/common -I$(LIBDIR)/dictBuilder -I$(PROGDIR)
+
+CFLAGS  ?= -O3 -g
+CFLAGS  += -std=gnu99
+DEBUGFLAGS= -Wall -Wextra -Wcast-qual -Wcast-align -Wshadow \
+            -Wstrict-aliasing=1 -Wswitch-enum \
+            -Wstrict-prototypes -Wundef -Wpointer-arith \
+            -Wvla -Wformat=2 -Winit-self -Wfloat-equal -Wwrite-strings \
+            -Wredundant-decls
+CFLAGS  += $(DEBUGFLAGS) $(MOREFLAGS)
+
+
+default: seqBench
+
+all : seqBench
+
+seqBench: util.o timefn.o benchfn.o datagen.o xxhash.o seqBench.c $(LIBZSTD)
+	$(CC) $(CPPFLAGS) $(CFLAGS) $^ $(LDFLAGS) -o $@
+
+.PHONY: $(LIBZSTD)
+$(LIBZSTD):
+	$(MAKE) -C $(LIBDIR) libzstd.a CFLAGS="$(CFLAGS)"
+
+benchfn.o: $(PROGDIR)/benchfn.c
+	$(CC) $(CPPFLAGS) $(CFLAGS) $^ -c
+
+timefn.o: $(PROGDIR)/timefn.c
+	$(CC) $(CPPFLAGS) $(CFLAGS) $^ -c
+
+datagen.o: $(PROGDIR)/datagen.c
+	$(CC) $(CPPFLAGS) $(CFLAGS) $^ -c
+
+util.o: $(PROGDIR)/util.c
+	$(CC) $(CPPFLAGS) $(CFLAGS) $^ -c
+
+
+xxhash.o : $(LIBDIR)/common/xxhash.c
+	$(CC) $(CPPFLAGS) $(CFLAGS) $^ -c
+
+
+clean:
+	$(RM) *.o
+	$(MAKE) -C $(LIBDIR) clean > /dev/null
+	$(RM) seqBench

--- a/contrib/seqBench/seqBench.c
+++ b/contrib/seqBench/seqBench.c
@@ -1,0 +1,55 @@
+#define ZSTD_STATIC_LINKING_ONLY
+#include <zstd.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+#include <string.h>
+
+int main(int argc, char *argv[]) {
+    ZSTD_CCtx* zc = ZSTD_createCCtx();
+
+    if (argc != 2) {
+        printf("Usage: seqBench <file>\n"); // TODO provide the block delim option here
+        return 1;
+    }
+
+    FILE *f = fopen(argv[1], "rb");
+    fseek(f, 0, SEEK_END);
+    long inBufSize = ftell(f);
+    fseek(f, 0, SEEK_SET);
+
+    char *inBuf = malloc(inBufSize + 1);
+    fread(inBuf, inBufSize, 1, f);
+    fclose(f);
+
+    // Should work fine for this benchmark, but we really need
+    // a function like ZSTD_compressBound() for sequences
+    size_t seqsSize = 2 * (inBufSize / sizeof(ZSTD_Sequence));
+    ZSTD_Sequence *seqs = (ZSTD_Sequence*)malloc(seqsSize * sizeof(ZSTD_Sequence));
+    char *outBuf = malloc(ZSTD_compressBound(inBufSize));
+
+    ZSTD_generateSequences(zc, seqs, seqsSize, inBuf, inBufSize);
+    ZSTD_CCtx_setParameter(zc, ZSTD_c_blockDelimiters, ZSTD_sf_explicitBlockDelimiters);
+    size_t outBufSize = ZSTD_compressSequences(zc, outBuf, inBufSize, seqs, seqsSize, inBuf, inBufSize);
+    if (ZSTD_isError(outBufSize)) {
+        printf("ERROR: %lu\n", outBufSize);
+        return 1;
+    }
+
+    char *validationBuf = malloc(inBufSize);
+    ZSTD_decompress(validationBuf, inBufSize, outBuf, outBufSize);
+
+    if (memcmp(inBuf, validationBuf, inBufSize) == 0) {
+        printf("Compression and decompression were successful!\n");
+    } else {
+        printf("ERROR: input and validation buffers don't match!\n");
+        for (int i = 0; i < inBufSize; i++) {
+            if (inBuf[i] != validationBuf[i]) {
+                printf("First bad index: %d\n", i);
+                break;
+            }
+        }
+    }
+
+    return 0;
+}

--- a/contrib/seqBench/seqBench.c
+++ b/contrib/seqBench/seqBench.c
@@ -28,12 +28,16 @@ int main(int argc, char *argv[]) {
     ZSTD_Sequence *seqs = (ZSTD_Sequence*)malloc(seqsSize * sizeof(ZSTD_Sequence));
     char *outBuf = malloc(ZSTD_compressBound(inBufSize));
 
+    ZSTD_CCtx_setParameter(zc, ZSTD_c_compressionLevel, ZSTD_fast);
     ZSTD_generateSequences(zc, seqs, seqsSize, inBuf, inBufSize);
     ZSTD_CCtx_setParameter(zc, ZSTD_c_blockDelimiters, ZSTD_sf_explicitBlockDelimiters);
     size_t outBufSize = ZSTD_compressSequences(zc, outBuf, inBufSize, seqs, seqsSize, inBuf, inBufSize);
     if (ZSTD_isError(outBufSize)) {
         printf("ERROR: %lu\n", outBufSize);
         return 1;
+    } else {
+        printf("Uncompressed size: %lu\n", inBufSize);
+        printf("Compressed size: %lu\n", outBufSize);
     }
 
     char *validationBuf = malloc(inBufSize);

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -5943,10 +5943,11 @@ ZSTD_copySequencesToSeqStoreExplicitBlockDelim(ZSTD_CCtx* cctx,
     ZSTD_memcpy(updatedRepcodes.rep, cctx->blockState.prevCBlock->rep, sizeof(repcodes_t));
     for (; idx < inSeqsSize && (inSeqs[idx].matchLength != 0 || inSeqs[idx].offset != 0); ++idx) {
         U32 const litLength = inSeqs[idx].litLength;
-        U32 const ll0 = (litLength == 0);
+        // U32 const ll0 = (litLength == 0);
         U32 const matchLength = inSeqs[idx].matchLength;
-        U32 const offBase = ZSTD_finalizeOffBase(inSeqs[idx].offset, updatedRepcodes.rep, ll0);
-        ZSTD_updateRep(updatedRepcodes.rep, offBase, ll0);
+        // U32 const offBase = ZSTD_finalizeOffBase(inSeqs[idx].offset, updatedRepcodes.rep, ll0);
+        U32 const offBase = OFFSET_TO_OFFBASE(inSeqs[idx].offset);
+        // ZSTD_updateRep(updatedRepcodes.rep, offBase, ll0);
 
         DEBUGLOG(6, "Storing sequence: (of: %u, ml: %u, ll: %u)", offBase, matchLength, litLength);
         if (cctx->appliedParams.validateSequences) {

--- a/lib/compress/zstd_fast.c
+++ b/lib/compress/zstd_fast.c
@@ -224,7 +224,8 @@ _start: /* Requires: ip0 */
         hashTable[hash0] = current0;
 
         /* check repcode at ip[2] */
-        if ((MEM_read32(ip2) == rval) & (rep_offset1 > 0)) {
+        /* Disable repcode check to simulate accelerator behavior */
+        if (0 && (MEM_read32(ip2) == rval) & (rep_offset1 > 0)) {
             ip0 = ip2;
             match0 = ip0 - rep_offset1;
             mLength = ip0[-1] == match0[-1];
@@ -387,7 +388,8 @@ _match: /* Requires: ip0, match0, offcode */
         hashTable[ZSTD_hashPtr(ip0-2, hlog, mls)] = (U32)(ip0-2-base);
 
         if (rep_offset2 > 0) { /* rep_offset2==0 means rep_offset2 is invalidated */
-            while ( (ip0 <= ilimit) && (MEM_read32(ip0) == MEM_read32(ip0 - rep_offset2)) ) {
+            /* Disable repcode check to simulate accelerator behavior */
+            while (0 && (ip0 <= ilimit) && (MEM_read32(ip0) == MEM_read32(ip0 - rep_offset2)) ) {
                 /* store sequence */
                 size_t const rLength = ZSTD_count(ip0+4, ip0+4-rep_offset2, iend) + 4;
                 { U32 const tmpOff = rep_offset2; rep_offset2 = rep_offset1; rep_offset1 = tmpOff; } /* swap rep_offset2 <=> rep_offset1 */


### PR DESCRIPTION
Benchmark + patch to improve performance of the Sequence Compression API (see commented lines in `zstd_compress.c`). Improves performance by disabling repcode support in `ZSTD_copySequencesToSeqStoreExplicitBlockDelim()`, which is fine as long as the sequence producer isn't optimized for finding repcode matches (like our normal zstd matchfinders are).

I disabled repcode search in `ZSTD_fast.c` to simulate such a scenario, and found that disabling repcode support in `ZSTD_copySequencesToSeqStoreExplicitBlockDelim()` hurts ratio by less than 1% (when the matchfinder itself is not actively searching for repcodes).

**`ZSTD_copySequencesToSeqStoreExplicitBlockDelim()` speed is 2x higher with the changes in this PR**. I measured this using `perf`, since there's a lot of overhead in the benchmark tool.

To reproduce my results for speed and ratio, undo the changes in `zstd_compress.c`. Don't undo the changes in `zstd_fast.c`, since those let us simulate the non-repcode-optimized sequence producer. Then 
```
cd contrib/seqBench
make -j
perf record -g --call-graph=lbr -- ./seqBench path/to/silesia.tar
perf report
```

This PR is not mergeable due to the changes in `ZSTD_fast.c`. Also, we would want to create a separate variant function rather than disabling repcode support entirely for ZSTD_copySequences. However, this PR does demonstrate that we can improve performance by at least 2x, so we don't need to look for an alternative encoding / format.

Here is the patch by itself:
```
diff --git a/lib/compress/zstd_compress.c b/lib/compress/zstd_compress.c
index 59d441b2..14d9675a 100644
--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -5943,10 +5943,8 @@ ZSTD_copySequencesToSeqStoreExplicitBlockDelim(ZSTD_CCtx* cctx,
     ZSTD_memcpy(updatedRepcodes.rep, cctx->blockState.prevCBlock->rep, sizeof(repcodes_t));
     for (; idx < inSeqsSize && (inSeqs[idx].matchLength != 0 || inSeqs[idx].offset != 0); ++idx) {
         U32 const litLength = inSeqs[idx].litLength;
-        U32 const ll0 = (litLength == 0);
         U32 const matchLength = inSeqs[idx].matchLength;
-        U32 const offBase = ZSTD_finalizeOffBase(inSeqs[idx].offset, updatedRepcodes.rep, ll0);
-        ZSTD_updateRep(updatedRepcodes.rep, offBase, ll0);
+        U32 const offBase = OFFSET_TO_OFFBASE(inSeqs[idx].offset);
 
         DEBUGLOG(6, "Storing sequence: (of: %u, ml: %u, ll: %u)", offBase, matchLength, litLength);
         if (cctx->appliedParams.validateSequences) {
```